### PR TITLE
Fix typo in variable default value

### DIFF
--- a/precopy_appsync.sh
+++ b/precopy_appsync.sh
@@ -2,7 +2,7 @@
 
 APP_VOLUME=${APP_VOLUME:-/app_sync}
 HOST_VOLUME=${HOST_VOLUME:-/host_sync}
-OWNER_UID=${OWNER_UID:0}
+OWNER_UID=${OWNER_UID:-0}
 
 if [ ! -f /unison/initial_sync_finished ]; then
 	echo "doing initial sync with cp"


### PR DESCRIPTION
This was causing `docker-sync start` to hang on [this line](https://github.com/EugenMayer/docker-sync/blob/master/lib/docker-sync/sync_strategy/native_osx.rb#L72) because the following command was erroring due to an argument missing (since `OWNER_UID` was unititialized instead of being `0` as expected):

```
→ docker run -it --rm -v core-sync:/app_sync -v /Users/mike/code/kyero/core:/host_sync -e HOST_VOLUME=/host_sync -e APP_VOLUME=/app_sync -e TZ=Europe/Paris -e UNISON_EXCLUDES="-ignore='Path log' -ignore='Path tmp' -ignore='Path .git' -ignore='Path .bundle' -ignore='Path .idea'" -e UNISON_ARGS="" -e UNISON_SYNC_PREFER="-prefer /host_sync" --name core-sync eugenmayer/unison:hostsync /usr/local/bin/precopy_appsync
doing initial sync with cp
real	0m 0.97s
user	0m 0.01s
sys	0m 0.10s
chown ing file to uid
BusyBox v1.26.2 (2017-02-21 17:41:44 GMT) multi-call binary.

Usage: chown [-RhLHPcvf]... USER[:[GRP]] FILE...

Change the owner and/or group of each FILE to USER and/or GRP

	-R	Recurse
	-h	Affect symlinks instead of symlink targets
	-L	Traverse all symlinks to directories
	-H	Traverse symlinks on command line only
	-P	Don't traverse symlinks (default)
	-c	List changed files
	-v	List all files
	-f	Hide errors
```

ℹ️ _Note:_ to reproduce, be sure to **not** define `sync_userid` in `docker-sync.yml` 