### PR TITLE
Make unison directory stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,14 @@ RUN mkdir -p /docker-entrypoint.d \
 COPY supervisord.conf /etc/supervisord.conf
 COPY supervisor.daemon.conf /etc/supervisor.conf.d/supervisor.daemon.conf
 
+ENV UNISON=/.unison
+RUN mkdir /.unison
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["supervisord"]
 ############# ############# #############
 ############# /SHARED     / #############
 ############# ############# #############
 
+VOLUME /.unison
 EXPOSE 500

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,8 @@ COPY supervisor.daemon.conf /etc/supervisor.conf.d/supervisor.daemon.conf
 ENV UNISON=/.unison
 RUN mkdir /.unison
 
+ENV UNISONLOCALHOSTNAME=dockersync
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["supervisord"]
 ############# ############# #############

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,8 @@ if [ "$1" == 'supervisord' ]; then
 
 	chown -R $OWNER_UID $VOLUME
 
+	chown -R $OWNER_UID $UNISON
+
 	# see https://wiki.alpinelinux.org/wiki/Setting_the_timezone
 	if [ -n ${TZ} ] && [ -f /usr/share/zoneinfo/${TZ} ]; then
 		ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime


### PR DESCRIPTION
Unison stores metadata in a directory in file called "Archives". You may read more information about this here : http://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html#unisondir.

This pull request make the archive location consistant regardless the configured user UID, so user can keep this file event if container is destroyed by mapping the UNISON directory containing the archive to a docker VOLUME.

Mapping the UNISON directory in a docker volume avoid the warning on unison client that occurs after each restart of the unison container.

```
Warning: No archive files were found for these roots, whose canonical names are:
        <root1>
        <root2>
This can happen either
because this is the first time you have synchronized these roots,
or because you have upgraded Unison to a new version with a different
archive format.
```

It may also solve issues that could occur when this message is displayed due to missing archive on the server. It also avoid new client-side archives to be created after each container restart.

FYI, a docker compose configuration

```
services:
  unison:
    image: toilal/unison:2.48.4 # fork of eugenmayer/unison
    environment:
      - VOLUME=/var/www/html
      - OWNER_UID=1000
      - UNISONLOCALHOSTNAME=my-app
    ports:
      - "5000:5000"
    volumes:
      - ".:/var/www/html"
      - "unison-volume:/.unison"
volumes:
  unison-volume: ~
