### PR TITLE
Use Monit to auto restart if CPU usage high in Native OSX strategy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:edge
 
 ARG UNISON_VERSION=2.48.4
-RUN apk add --no-cache build-base curl bash supervisor inotify-tools rsync ruby\
+RUN apk add --no-cache build-base curl bash monit supervisor inotify-tools rsync ruby\
     && apk add --update-cache --repository http://dl-4.alpinelinux.org/alpine/edge/testing/ ocaml \
     && curl -L https://github.com/bcpierce00/unison/archive/$UNISON_VERSION.tar.gz | tar zxv -C /tmp \
     && cd /tmp/unison-${UNISON_VERSION} \
@@ -26,6 +26,7 @@ ENV TZ="Europe/Helsinki" \
 
 COPY entrypoint.sh /entrypoint.sh
 COPY precopy_appsync.sh /usr/local/bin/precopy_appsync
+COPY monitrc /etc/monitrc
 
 RUN mkdir -p /docker-entrypoint.d \
  && chmod +x /entrypoint.sh \
@@ -33,7 +34,8 @@ RUN mkdir -p /docker-entrypoint.d \
  && mkdir /unison \
  && touch /tmp/unison.log \
  && chmod u=rw,g=rw,o=rw /tmp/unison.log \
- && chmod +x /usr/local/bin/precopy_appsync
+ && chmod +x /usr/local/bin/precopy_appsync \
+ && chmod u=rw,g=,o= /etc/monitrc
 
 COPY supervisord.conf /etc/supervisord.conf
 COPY supervisor.daemon.conf /etc/supervisor.conf.d/supervisor.daemon.conf

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,7 +69,7 @@ if [ "$1" == 'supervisord' ]; then
 	# Needs the privilegied docker option
 	[ ! -z $MAX_INOTIFY_WATCHES ] && echo fs.inotify.max_user_watches=$MAX_INOTIFY_WATCHES | tee -a /etc/sysctl.conf && sysctl -p || true
 
-	MONIT_ENABLE=${MONIT_ENABLE:-true}
+	MONIT_ENABLE=${MONIT_ENABLE:-false}
 	MONIT_INTERVAL=${MONIT_INTERVAL:-5}
 	MONIT_HIGH_CPU_CYCLES=${MONIT_HIGH_CPU_CYCLES:-2}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,7 +73,7 @@ if [ "$1" == 'supervisord' ]; then
 	MONIT_INTERVAL=${MONIT_INTERVAL:-5}
 	MONIT_HIGH_CPU_CYCLES=${MONIT_HIGH_CPU_CYCLES:-2}
 
-	sed -i -e "s/MONIT_HIGH_CPU_CYCLES/$MONIT_HIGH_CPU_CYCLES/g" /etc/monitrc
+	sed -i -e "s/{{MONIT_HIGH_CPU_CYCLES}}/$MONIT_HIGH_CPU_CYCLES/g" /etc/monitrc
 
 	export MONIT_ENABLE
 	export MONIT_INTERVAL

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,6 +68,16 @@ if [ "$1" == 'supervisord' ]; then
 	# Increase the maximum watches for inotify for very large repositories to be watched
 	# Needs the privilegied docker option
 	[ ! -z $MAX_INOTIFY_WATCHES ] && echo fs.inotify.max_user_watches=$MAX_INOTIFY_WATCHES | tee -a /etc/sysctl.conf && sysctl -p || true
+
+	MONIT_ENABLE=${MONIT_ENABLE:-true}
+	MONIT_INTERVAL=${MONIT_INTERVAL:-5}
+	MONIT_HIGH_CPU_CYCLES=${MONIT_HIGH_CPU_CYCLES:-2}
+
+	sed -i -e "s/MONIT_HIGH_CPU_CYCLES/$MONIT_HIGH_CPU_CYCLES/g" /etc/monitrc
+
+	export MONIT_ENABLE
+	export MONIT_INTERVAL
+
 	################### ################### ###################
 	################### /now unison specific/ ###################
 	################### ################### ###################

--- a/monitrc
+++ b/monitrc
@@ -3,4 +3,4 @@ check process unison with pidfile /var/run/unison.pid
   start program = "/bin/bash -c 'while [ ! -S /tmp/supervisor.sock ]; do sleep 1; done && supervisorctl start unison && supervisorctl pid unison > /var/run/unison.pid'"
   stop program = "/bin/bash -c 'supervisorctl stop unison && rm -rf /var/run/unison.pid'"
   # Restart if CPU usage is high based on cycles configuration. Value is replaced inline during startup
-  if cpu usage > 50% for MONIT_HIGH_CPU_CYCLES cycles then restart
+  if cpu usage > 50% for {{MONIT_HIGH_CPU_CYCLES}} cycles then restart

--- a/monitrc
+++ b/monitrc
@@ -1,0 +1,4 @@
+check process unison with pidfile /var/run/unison.pid
+  start program = "/bin/bash -c 'supervisorctl start unison && supervisorctl pid unison > /var/run/unison.pid'"
+  stop program = "/bin/bash -c 'supervisorctl stop unison && rm -rf /var/run/unison.pid'"
+  if cpu usage > 50% for 2 cycles then restart

--- a/monitrc
+++ b/monitrc
@@ -1,4 +1,6 @@
 check process unison with pidfile /var/run/unison.pid
+  # Wait for supervisor to be ready, then start unison and store the PID
   start program = "/bin/bash -c 'while [ ! -S /tmp/supervisor.sock ]; do sleep 1; done && supervisorctl start unison && supervisorctl pid unison > /var/run/unison.pid'"
   stop program = "/bin/bash -c 'supervisorctl stop unison && rm -rf /var/run/unison.pid'"
-  if cpu usage > 50% for 2 cycles then restart
+  # Restart if CPU usage is high based on cycles configuration. Value is replaced inline during startup
+  if cpu usage > 50% for MONIT_HIGH_CPU_CYCLES cycles then restart

--- a/monitrc
+++ b/monitrc
@@ -1,4 +1,4 @@
 check process unison with pidfile /var/run/unison.pid
-  start program = "/bin/bash -c 'supervisorctl start unison && supervisorctl pid unison > /var/run/unison.pid'"
+  start program = "/bin/bash -c 'while [ ! -S /tmp/supervisor.sock ]; do sleep 1; done && supervisorctl start unison && supervisorctl pid unison > /var/run/unison.pid'"
   stop program = "/bin/bash -c 'supervisorctl stop unison && rm -rf /var/run/unison.pid'"
   if cpu usage > 50% for 2 cycles then restart

--- a/supervisor.daemon.conf
+++ b/supervisor.daemon.conf
@@ -5,3 +5,9 @@ directory = %(ENV_APP_VOLUME)s
 environment=HOME="%(ENV_OWNER_HOMEDIR)s",USER="%(ENV_OWNER)s"
 redirect_stderr = true
 autorestart=true
+
+[program:monit]
+command = monit -c /etc/monitrc -d 5 -v -I
+redirect_stderr = true
+autorestart = true
+priority = 1000

--- a/supervisor.daemon.conf
+++ b/supervisor.daemon.conf
@@ -10,4 +10,4 @@ autorestart=true
 command = monit -c /etc/monitrc -d 5 -I
 redirect_stderr = true
 autorestart = true
-priority = 1000
+autostart = %(ENV_ENABLE_MONIT)s

--- a/supervisor.daemon.conf
+++ b/supervisor.daemon.conf
@@ -7,7 +7,7 @@ redirect_stderr = true
 autorestart=true
 
 [program:monit]
-command = monit -c /etc/monitrc -d 5 -I
+command = monit -c /etc/monitrc -d %(ENV_MONIT_INTERVAL)s -I
 redirect_stderr = true
 autorestart = true
-autostart = %(ENV_ENABLE_MONIT)s
+autostart = %(ENV_MONIT_ENABLE)s

--- a/supervisor.daemon.conf
+++ b/supervisor.daemon.conf
@@ -7,7 +7,7 @@ redirect_stderr = true
 autorestart=true
 
 [program:monit]
-command = monit -c /etc/monitrc -d 5 -v -I
+command = monit -c /etc/monitrc -d 5 -I
 redirect_stderr = true
 autorestart = true
 priority = 1000


### PR DESCRIPTION
- Fixes https://github.com/EugenMayer/docker-sync/issues/497
- Issue has repro steps
- Adds monit and configuration files
- Configuration details here: https://github.com/EugenMayer/docker-sync/pull/521
- `monitrc` does not support environment variables, so did a simple replacement in-place in the entrypoint