### PR TITLE
Outside docker sync issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can configure how unison runs by using the following ENV variables:
  
  - `APP_VOLUME` specifies the directory created in the container to store the synced files, `/data` by default
  - `OWNER_UID` specifies **the ID of the user** on which the unison process run and the owner of the synced files.
- - `MAX_INOTIFY_WATCHES` increases the limit of inotify watches if you need to sync folders with lots of files. 
+ - `MAX_INOTIFY_WATCHES` increases the limit of inotify watches if you need to sync folders with lots of files (container need to be run on privileged mode to adjust this setting)
 
 ## Credits
 - Big thanks at [mickaelperrin](https://github.com/mickaelperrin) for putting hard work into getting this production ready

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -83,6 +83,20 @@ if [ "$1" == 'supervisord' ]; then
 	################### ################### ###################
     chown -R ${OWNER_UID} /unison
     chown ${OWNER_UID} /tmp/unison.log
+    # If some files/dirs are generated in sync volume before inital sync
+    # Unison may fail to use them if they don't have the adequate UID
+    chown -R ${OWNER_UID} ${APP_VOLUME}
+    # Export default variables used in supervisor
+    # If they don't exist, supervisor won't run
+    export UNISON_SRC=${UNISON_SRC:-}
+    export UNISON_DEST=${UNISON_DEST:-}
+    # If src is not given, by default launch a socket
+    if [ -z $UNISON_SRC ]; then
+      export UNISON_ARGS=${UNISON_ARGS:--socket 5000}
+    fi
+    export UNISON_ARGS=${UNISON_ARGS:-}
+    # By default ignore .git
+    export UNISON_WATCH_ARGS=${UNISON_WATCH_ARGS:--ignore='Name .git'}
 fi
 
 exec "$@"


### PR DESCRIPTION
The original image have been hard replaced by the new one used in unison and native docker_sync strategies.

The update of this image removed one critical action and introduced some issues when used outside of docker-sync:

1/ The synced volume may contains files / directories bootstrapped by other containers. The files in this folder may be owned by a different UID. Normally they should have the same UID, but in my case, some files are generated before the UID change of the process.
2/ Some optional environment variables are not defined and prevent supervisor to start.

I also introduced these default settings.
- by default ignore .git in the watch/sync process
- If no UNISON_SRC and no UNISON_ARGS variable are defined, start the unison process in daemon mode by opening a socket on port 5000.
- Small documentation update on the privileged mode requirement to use MAX_INOTIFY_WATCHES
