### PR TITLE
Support configuring the OCAML version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,28 @@
 FROM alpine:edge
 
+ARG OCAML_VERSION=4.08.1
+
+RUN apk update \
+    && apk add --no-cache --virtual .build-deps build-base coreutils \
+	&& wget http://caml.inria.fr/pub/distrib/ocaml-${OCAML_VERSION:0:4}/ocaml-${OCAML_VERSION}.tar.gz \
+	&& tar xvf ocaml-${OCAML_VERSION}.tar.gz -C /tmp \
+	&& cd /tmp/ocaml-${OCAML_VERSION} \
+    && ./configure \
+    && make world \
+    && make opt \
+    && umask 022 \
+    && make install \
+    && make clean \
+    && apk del .build-deps  \
+	&& rm -rf /tmp/ocaml-${OCAML_VERSION} \
+	&& rm /ocaml-${OCAML_VERSION}.tar.gz
+
 ARG UNISON_VERSION=2.51.2
 
 RUN apk update \
     && apk add --no-cache --repository="http://dl-cdn.alpinelinux.org/alpine/v3.10/main" binutils=2.33.1-r0 \
     && apk add --no-cache --virtual .build-deps \
-        build-base curl git ocaml=4.08.1-r0 \
+        build-base curl git \
     && apk add --no-cache \
         bash inotify-tools monit supervisor rsync ruby \
     && curl -L https://github.com/bcpierce00/unison/archive/v$UNISON_VERSION.tar.gz | tar zxv -C /tmp \

--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 This image is the unison-image for [docker-sync](https://github.com/EugenMayer/docker-sync) and published on [eugenmayer/unison](https://hub.docker.com/r/eugenmayer/unison/).
 
+The image is used by docker-sync by default, unless it is overridden using the configuration option _<sync\_strategy>\_image_ in [docker-sync.yml](https://docker-sync.readthedocs.io/en/latest/getting-started/configuration.html#references). The image uses the latest OCaml and Unison versions available at the time of release. Incase other versions needs to be used (which matches the versions used with docker-sync on the host), build a new docker-image-unison image as follows:
+
+`docker build --build-arg "OCAML_VERSION=<ocaml-version>" --build-arg "UNISON_VERSION=<unison-version>" -t custom-docker-image-unison .`
+
+where `ocaml-version` is any OCaml version available as source-code [here](http://caml.inria.fr/pub/distrib/) and `unison-version` is any Unison version available as source code [here](https://github.com/bcpierce00/unison/).
+
+For example,
+
+`docker build --build-arg "OCAML_VERSION=4.06.1" --build-arg "UNISON_VERSION=2.51.2" -t custom-docker-image-unison .`
+
+The configuration in the docker-sync.yml would then be:
+
+_unison\_image_: 'custom-docker-image-unison'
+
 A lot of credits go to [mickaelperrin](https://github.com/mickaelperrin) - most of the work has been done by him initially.
 
 ## What does it do ?

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The image is used by docker-sync by default, unless it is overridden using the c
 
 `docker build --build-arg "OCAML_VERSION=<ocaml-version>" --build-arg "UNISON_VERSION=<unison-version>" -t custom-docker-image-unison .`
 
-where `ocaml-version` is any OCaml version available as source-code [here](http://caml.inria.fr/pub/distrib/) and `unison-version` is any Unison version available as source code [here](https://github.com/bcpierce00/unison/).
+where `ocaml-version` is any OCaml version available as source-code [here](http://caml.inria.fr/pub/distrib/) and `unison-version` is any Unison version available as source code [here](https://github.com/bcpierce00/unison/releases/).
 
 For example,
 


### PR DESCRIPTION
The current docker-image-unison relies on OCAML versions available within Alpine. Just like a Unison version could be chosen, it would be nice if OCAML versions could be chosen too. 

I had to use a OCAML 4.06.1 and Unison 2.51.2 which  is not possible with the current image.

The PR compiles the chosen OCAML version and uses it for compiling unison as before.  The size of the image is also reduced from the earlier 485MB to 280MB. The disadvantage is of course the increased build time of the image because of the time required to compile OCAML.