### PR TITLE
Unifies logging into stdout, fixes empty unison.log

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,6 @@ RUN mkdir -p /docker-entrypoint.d \
  && chmod +x /entrypoint.sh \
  && mkdir -p /etc/supervisor.conf.d \
  && mkdir /unison \
- && touch /tmp/unison.log \
- && chmod u=rw,g=rw,o=rw /tmp/unison.log \
  && chmod +x /usr/local/bin/precopy_appsync \
  && chmod u=rw,g=,o= /etc/monitrc
 

--- a/supervisor.daemon.conf
+++ b/supervisor.daemon.conf
@@ -1,13 +1,17 @@
 [program:unison]
-command = unison %(ENV_UNISON_ARGS)s %(ENV_UNISON_WATCH_ARGS)s %(ENV_UNISON_SRC)s %(ENV_UNISON_DEST)s -logfile /tmp/unison.log
+command = unison %(ENV_UNISON_ARGS)s %(ENV_UNISON_WATCH_ARGS)s %(ENV_UNISON_SRC)s %(ENV_UNISON_DEST)s
 user = %(ENV_OWNER)s
 directory = %(ENV_APP_VOLUME)s
 environment=HOME="%(ENV_OWNER_HOMEDIR)s",USER="%(ENV_OWNER)s"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 redirect_stderr = true
 autorestart=true
 
 [program:monit]
 command = monit -c /etc/monitrc -d %(ENV_MONIT_INTERVAL)s -I
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 redirect_stderr = true
 autorestart = true
 autostart = %(ENV_MONIT_ENABLE)s


### PR DESCRIPTION
Currently, logging doesn't work as expected:
```
ls -ls /tmp/
total 531728
     0 -rw-------    1 root     root             0 Apr 25 02:30 monit-stdout---supervisor-jE8Kdx.log
     0 srwx------    1 root     root             0 Apr 25 02:30 supervisor.sock
    12 -rw-r--r--    1 root     root         10685 Apr 25 12:23 supervisord.log
     4 -rw-r--r--    1 root     root             2 Apr 25 02:30 supervisord.pid
 19628 -rw-r--r--    1 root     root      20097343 Apr 25 12:23 unison-stdout---supervisor-JHhBXk.log
 51204 -rw-r--r--    1 root     root      52428861 Apr 25 03:21 unison-stdout---supervisor-JHhBXk.log.1
 51212 -rw-r--r--    1 root     root      52437692 Apr 25 03:15 unison-stdout---supervisor-JHhBXk.log.10
 51204 -rw-r--r--    1 root     root      52432255 Apr 25 03:20 unison-stdout---supervisor-JHhBXk.log.2
 51204 -rw-r--r--    1 root     root      52430230 Apr 25 03:20 unison-stdout---supervisor-JHhBXk.log.3
 51204 -rw-r--r--    1 root     root      52429104 Apr 25 03:18 unison-stdout---supervisor-JHhBXk.log.4
 51216 -rw-r--r--    1 root     root      52442028 Apr 25 03:17 unison-stdout---supervisor-JHhBXk.log.5
 51212 -rw-r--r--    1 root     root      52438895 Apr 25 03:17 unison-stdout---supervisor-JHhBXk.log.6
 51208 -rw-r--r--    1 root     root      52433297 Apr 25 03:17 unison-stdout---supervisor-JHhBXk.log.7
 51216 -rw-r--r--    1 root     root      52443988 Apr 25 03:16 unison-stdout---supervisor-JHhBXk.log.8
 51204 -rw-r--r--    1 root     root      52430102 Apr 25 03:15 unison-stdout---supervisor-JHhBXk.log.9
     0 -rw-rw-rw-    1 root     root             0 Oct 24  2019 unison.log
 ```

 As can be seen above, unison.log is empty. This change makes it so all logs are available via `docker logs` command instead, where it works reliably.

Used https://stackoverflow.com/a/39127732/524965