### PR TITLE
Remove explicit binutils installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN apk update \
 ARG UNISON_VERSION=2.51.2
 
 RUN apk update \
-    && apk add --no-cache --repository="http://dl-cdn.alpinelinux.org/alpine/v3.10/main" binutils=2.33.1-r0 \
     && apk add --no-cache --virtual .build-deps \
         build-base curl git \
     && apk add --no-cache \


### PR DESCRIPTION
This pinning to specific version is not needed anymore, as can be seen by successfully building this Dockerfile.

Supersedes https://github.com/EugenMayer/docker-image-unison/pull/11
More information in https://github.com/EugenMayer/docker-image-unison/pull/11#issuecomment-619428123