### PR TITLE
Run ARM64 builds on ARM64 machines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,28 @@
 services:
   - docker
-env:
-  matrix:
-    - ARCH="AMD64" BASE_IMAGE=alpine:3.12 OCAML_VERSION=4.12.0 UNISON_VERSION=2.51.3
-    - ARCH="AMD64" BASE_IMAGE=alpine:3.12 OCAML_VERSION=4.12.0 UNISON_VERSION=2.51.4_rc2
-    - ARCH="ARM64" BASE_IMAGE=arm64v8/alpine:3.12 OCAML_VERSION=4.12.0 UNISON_VERSION=2.51.3
-    - ARCH="ARM64" BASE_IMAGE=arm64v8/alpine:3.12 OCAML_VERSION=4.12.0 UNISON_VERSION=2.51.4_rc2
+
 jobs:
   include:
     - name: default
       script: docker build . -t eugenmayer/unison:latest
+    - env: BASE_IMAGE=alpine:3.12 OCAML_VERSION=4.12.0 UNISON_VERSION=2.51.3
+      arch: amd64
+    - env: BASE_IMAGE=alpine:3.12 OCAML_VERSION=4.12.0 UNISON_VERSION=2.51.4_rc2
+      arch: amd64
+    - env: BASE_IMAGE=arm64v8/alpine:3.12 OCAML_VERSION=4.12.0 UNISON_VERSION=2.51.3
+      arch: arm64
+    - env: BASE_IMAGE=arm64v8/alpine:3.12 OCAML_VERSION=4.12.0 UNISON_VERSION=2.51.4_rc2
+      arch: arm64
   allow_failures:
     # yet arm builds are option
-    - env: BASE_IMAGE=arm64v8/alpine:3.12 OCAML_VERSION=4.12.0 UNISON_VERSION=2.51.4_rc2
-    - env: BASE_IMAGE=arm64v8/alpine:3.12 OCAML_VERSION=4.12.0 UNISON_VERSION=2.51.3
+    - arch: arm64
 
-script: docker build --build-arg "BASE_IMAGE=$BASE_IMAGE" --build-arg "OCAML_VERSION=$OCAML_VERSION" --build-arg "UNISON_VERSION=$UNISON_VERSION"
-  . -t eugenmayer/unison:$UNISON_VERSION-$OCAML_VERSION-$ARCH
+script: docker build
+    --build-arg BASE_IMAGE=$BASE_IMAGE
+    --build-arg OCAML_VERSION=$OCAML_VERSION
+    --build-arg UNISON_VERSION=$UNISON_VERSION
+    --tag eugenmayer/unison:$UNISON_VERSION-$OCAML_VERSION-${TRAVIS_CPU_ARCH^^}
+    .
 
 deploy:
   provider: script


### PR DESCRIPTION
When building, the ARM64 images fail.

https://travis-ci.com/github/EugenMayer/docker-image-unison/jobs/503519313

```
standard_init_linux.go:190: exec user process caused "exec format error"
```

It looks like people have hit this error when building on an
architecture different than the target.
https://forums.docker.com/t/standard-init-linux-go-190-exec-user-process-caused-exec-format-error/49368/3

cc @EugenMayer 