### PR TITLE
Add defaults for needed env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,12 @@ FROM $BASE_IMAGE
 ARG OCAML_VERSION=4.12.0
 ARG UNISON_VERSION=2.52.1
 
+ENV UNISON_ARGS ''
+ENV UNISON_WATCH_ARGS ''
+ENV APP_VOLUME '/app_sync'
+ENV UNISON_SRC '/app_sync'
+ENV UNISON_DEST '/host_sync'
+
 RUN apk update \
     && apk add --no-cache --virtual .build-deps build-base curl git build-base coreutils \
     && curl -L http://caml.inria.fr/pub/distrib/ocaml-${OCAML_VERSION:0:4}/ocaml-${OCAML_VERSION}.tar.gz --output -  | tar zxv -C /tmp \

--- a/README.md
+++ b/README.md
@@ -49,10 +49,13 @@ A lot of credits go to [mickaelperrin](https://github.com/mickaelperrin) - most 
 ## Documentation
 
 You can configure how unison runs by using the following ENV variables:
-
-- `APP_VOLUME` specifies the directory created in the container to store the synced files, `/data` by default
+- `UNISON_SRC` th unison src - default is `/app_sync`
+- `UNISON_DEST` th unison dest  - default is `/host_sync`
+- `APP_VOLUME` specifies the directory created in the container to store the synced files, `/app_sync` by default
 - `OWNER_UID` specifies **the ID of the user** on which the unison process run and the owner of the synced files.
-- `MAX_INOTIFY_WATCHES` increases the limit of inotify watches if you need to sync folders with lots of files.
+- `MAX_INOTIFY_WATCHES` increases the limit of inotify watches if you need to sync folders with lots of files. 
+- `UNISON_ARGS` Pass individual args to unison.
+- `UNISON_WATCH_ARGS` Pass individual watch args for unison
 
 ## Credits
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ if [ "$1" == 'supervisord' ]; then
 
 	# if the user with the uid does not exist, create him, otherwise reuse him
 	if ! cut -d: -f3 /etc/passwd | grep -q ${OWNER_UID}; then
-		echo "no user has uid $OWNER_UID"
+		echo "no user has uid $OWNER_UID - creating user"
 
 		# If user doesn't exist on the system
 		useradd -u ${OWNER_UID} dockersync -m


### PR DESCRIPTION
Currently - somehow (maybe supervisor got stricter) the image references env vars in the supervisor unison startup, that are not set at all. This leads to an exception when the container is started (by supervisor)

This effort tries to add docs and add sane defaults.
